### PR TITLE
add rpkm output and split the id column

### DIFF
--- a/Results-template/Scripts/Deseq2Report.Rmd
+++ b/Results-template/Scripts/Deseq2Report.Rmd
@@ -90,7 +90,13 @@ ddsHTSeq<-DESeqDataSetFromMatrix(countData=x,colData=sampleinfo, design=~conditi
 dds<-DESeq(ddsHTSeq)
 ndata=as.data.frame(counts(dds,normalized=TRUE))
 colnames(ndata)=colnames(x)
-write.table(ndata,file="Deseq2_normalized_counts.txt",sep="\t",col.names=NA)
+
+rn=rownames(ndata)
+ensID=apply(array(as.character(rn)),1,function(z) unlist(strsplit(z, "\\|"))[1])
+gene=apply(array(as.character(rn)),1,function(z) unlist(strsplit(z, "\\|"))[2])
+mydata=cbind(ensID,gene,ndata)
+
+write.table(mydata,file="Deseq2_normalized_counts.txt",sep="\t",col.names=NA)
 #png("HistDesq2normFilter.png")
 df.m <- melt(as.data.frame(ndata))
 print(ggplot(df.m) + geom_density(aes(x = value, colour = variable)) + labs(x = NULL) + theme(legend.position='right') + scale_x_log10())
@@ -100,7 +106,9 @@ print(ggplot(df.m) + geom_density(aes(x = value, colour = variable)) + labs(x = 
 rld <- rlogTransformation(dds, blind=TRUE)
 rldm=assay(rld)
 colnames(rldm)=colnames(x)
-write.table(rldm,file="Deseq2_normalized_rld.txt",sep="\t",col.names=NA)
+
+mydata=cbind(ensID,gene,rldm)
+write.table(mydata,file="Deseq2_normalized_rld.txt",sep="\t",col.names=NA)
 
 ```
 ```{r, echo=FALSE, warning=FALSE,message=FALSE,include=FALSE}

--- a/Results-template/Scripts/EdgerReport.Rmd
+++ b/Results-template/Scripts/EdgerReport.Rmd
@@ -131,8 +131,15 @@ y <- estimateDisp(y, design, robust=TRUE)
 ylog2=cpm(y,log=TRUE,normalized.lib.sizes=TRUE,prior.count=2) # prior count like avelogcpm
 ndata= cpm(y,log=FALSE,normalized.lib.sizes=TRUE)*1e6
 ## save it
-write.table(ylog2,file="edgeR_normalized_counts_log.txt",sep="\t",col.names=NA)
-write.table(ndata,file="edgeR_normalized_counts.txt",sep="\t",col.names=NA)
+rn=rownames(ylog2)
+ensID=apply(array(as.character(rn)),1,function(z) unlist(strsplit(z, "\\|"))[1])
+gene=apply(array(as.character(rn)),1,function(z) unlist(strsplit(z, "\\|"))[2])
+mydata=cbind(ensID,gene,ylog2)
+
+write.table(mydata,file="edgeR_normalized_counts_log.txt",sep="\t",col.names=NA)
+mydata=cbind(ensID,gene,ndata)
+
+write.table(mydata,file="edgeR_normalized_counts.txt",sep="\t",col.names=NA)
 ## png("HistEdgeRnormFilter.png")
 df.m <- melt(as.data.frame(ndata))
 print(ggplot(df.m) + geom_density(aes(x = value, colour = variable)) + labs(x = NULL) + theme(legend.position='right') + scale_x_log10() + ggtitle("Normalized Counts"))

--- a/Results-template/Scripts/LimmaReport.Rmd
+++ b/Results-template/Scripts/LimmaReport.Rmd
@@ -105,8 +105,16 @@ v1 <- voom(as.matrix(x),design,plot=TRUE,normalize="quantile")
 #dev.off()
 
 sf = v1$E/log2((x/colSums(x))*1000000)
+
+rn=rownames(v1$E)
+ensID=apply(array(as.character(rn)),1,function(z) unlist(strsplit(z, "\\|"))[1])
+gene=apply(array(as.character(rn)),1,function(z) unlist(strsplit(z, "\\|"))[2])
+mydata=cbind(ensID,gene,v1$E)
+
+sf=cbind(ensID,gene,sf)
+
 write.table(sf,file="LimmaVoom_scaling_factors.txt",row.names=TRUE,col.names=NA,sep="\t",quote=FALSE)
-write.table(v1$E,file="LimmaVoom_Normalized_data.txt",row.names=TRUE,col.names=NA,sep="\t",quote=FALSE)
+write.table(mydata,file="LimmaVoom_Normalized_data.txt",row.names=TRUE,col.names=NA,sep="\t",quote=FALSE)
 
 #png("HistLimmavoomNormFilter.png")
 df.n <- melt(as.data.frame(v1$E))

--- a/Results-template/Scripts/genecounts.R
+++ b/Results-template/Scripts/genecounts.R
@@ -11,52 +11,69 @@ MINSAMPLES <- args[4]
 ANNOTATE <- args[5]
 
 setwd(DIR)
+
 myfiles=as.character(unlist(strsplit(FILES, split=" ")))
-res=read.delim(myfiles[1],header=T)
-colnames(res)[1]="gene"
-colnames(res)[2]=as.character(myfiles[1]) 
-# remove the last 5 statistics lines ... 
-# nr=dim(res)[1]
-# res=res[-c((nr-4):nr),]
-#
+
+#read first file for gene length data
+myfirstfiles = gsub("count", "count.info", myfiles[1])
+res=read.delim(myfirstfiles,header=T, comment.char = '#')
+colnames(res)[7]=as.character(myfiles[1]) 
+
+#read all other files and merge to the first one
 for(i in seq(2, length(myfiles), by = 1))
 {{
-temp=read.delim(myfiles[i],header=T)
-colnames(temp)[1]="gene"
-colnames(temp)[2]=as.character(myfiles[i]) 
-res=merge(res,temp)
+  temp=read.delim(myfiles[i],header=T)
+  colnames(temp)[2]=as.character(myfiles[i]) 
+  res=merge(res,temp)
 }}
+
+#read annotation flie and merge all together
 gene_name=read.delim(ANNOTATE,header=F,sep=" ")
 res2=merge(gene_name,res,by.x=1,by.y=1)
-res3=cbind(symbol=paste(res2[,1],"|",res2[,3],sep=""),res2[,-c(1,2,3,4,5)])
-write.table(as.data.frame(res3),file="RawCountFile_genes.txt",sep="\t",row.names=F) 
-#
-mydata=read.delim("RawCountFile_genes.txt",row.names=1)
+
+#reformat and output raw counts
+res2=cbind(Ensembl_id=res2[,1],Gene_symbol=res2[,3],res2[,-c(1:9)])
+write.table(as.data.frame(res2[,-c(3)]),file="RawCount_genes_unfiltered.txt",sep="\t",row.names=F) 
+
+#using DEGlist 
+mydata<-DGEList(counts=res2[,-c(1:3)],genes=res2[,c("Ensembl_id","Gene_symbol","Length")])
+
+#apply filter to counts
+MINCOUNT<-5
+MINSAMPLES<-2
 val1=as.numeric(MINCOUNT)
 val2=as.numeric(MINSAMPLES)
-cat(val1," ", val2, "checking..\n",file="check.txt")
-## filter <- apply(mydata, 1, function(x) length(x[x>val1])>=val2)
-## res=mydata[filter,]
-tot=colSums(mydata)
+
+tot=colSums(res2[,-c(1:3)])
 val1=(val1/max(tot))*1e6
-cat(val1," ", val2, "checking..\n",file="check2.txt")
+
 filter <- apply(cpm(mydata), 1, function(x) length(x[x>val1])>=val2)
-res=mydata[filter,]
-write.table(as.data.frame(res),file="RawCountFile_genes_filtered.txt",sep="\t",col.names=NA)
+res=mydata[filter,,keep.lib.sizes=FALSE]
+
+#output filtered raw counts, still output old format for the sake of pipeline, will change it soon.
+
+write.table(data.frame(cbind(symbol=paste(res$genes[,1],"|",res$genes[,2],sep=""),res$counts)),file="RawCountFile_genes_filtered.txt",sep="\t", row.names = F)
+
+#draw before png
 png("HistBeforenormFilter.png")
-df.m <- melt(as.data.frame(res))
+df.m <- melt(as.data.frame(res$counts))
 print(ggplot(df.m) + geom_density(aes(x = value, colour = variable)) + labs(x = NULL) + theme(legend.position='top') + scale_x_log10())
 dev.off() 
-y = DGEList(counts=res)
-## Normalization TMM ------------------------------------------------------------
-## method = =c("TMM","RLE","upperquartile","none")
-y <- calcNormFactors(y,method="TMM")
-ndata= cpm(y,log=FALSE,normalized.lib.sizes=TRUE)
-## save it 
-write.table(ndata,file="CPM_TMM_counts.txt",sep="\t",col.names=NA)
-	## unfiltered normalization
-y2 = DGEList(counts=mydata)
-y2 <- calcNormFactors(y2,method="TMM")
-ndata2= cpm(y2,log=FALSE,normalized.lib.sizes=TRUE)
-## save it 
-write.table(ndata2,file="CPM_TMM_unfiltered_counts.txt",sep="\t",col.names=NA)
+
+#calculate CPM_TMM and output
+tmm_y <- calcNormFactors(res,method="TMM")
+ndata= cpm(tmm_y,log=FALSE,normalized.lib.sizes=TRUE)
+write.table(data.frame(res$genes[,-c(3)], ndata),file="CPM_TMM_counts.txt",sep="\t",row.names=F)
+
+#calculate RPKM_TMM and output
+ndata = rpkm(tmm_y,res$genes$Length, log=FALSE,normalized.lib.sizes=TRUE)
+write.table(data.frame(res$genes[,-c(3)], ndata),file="RPKM_TMM_counts.txt",sep="\t",row.names=F)
+
+#calculate unfiltered CPM_TMM and output
+tmm_y <- calcNormFactors(mydata,method="TMM")
+ndata= cpm(tmm_y,log=FALSE,normalized.lib.sizes=TRUE)
+write.table(data.frame(mydata$genes[,-c(3)], ndata),file="CPM_TMM_unfiltered_counts.txt",sep="\t",row.names=F)
+
+#calculate unfiltered RPKM_TMM and output
+ndata = rpkm(tmm_y,res$genes$Length, log=FALSE,normalized.lib.sizes=TRUE)
+write.table(data.frame(mydata$genes[,-c(3)], ndata),file="RPKM_TMM_unfiltered_counts.txt",sep="\t",row.names=F)


### PR DESCRIPTION
Hi, 

I updated the genecounts.R to generate additional rpkm files from subread/featurecount output. 
and modified three markdown files (*.Rmd) to split the geneid column to two columns, en_id and symbol. 

I have run the pipeline without problem, please help to merge with the master.

Thanks

Jack