### PR TITLE
ChIP-seq multiQC improvements, and a few other minor details

### DIFF
--- a/Results-template/Scripts/createtable
+++ b/Results-template/Scripts/createtable
@@ -2,7 +2,7 @@
 '''
 Author:		Skyler Kuhn
 Date created:	08/18/2018
-Last modified:	04/17/2019 by Tovah Markowitz: markowitzte@nih.gov
+Last modified:	04/26/2019 by Tovah Markowitz: markowitzte@nih.gov
 Email:		kuhnsa@nih.gov
 
 About: This program takes standard input from the concatenation of each *qc.metric file.The results 
@@ -36,7 +36,7 @@ def file2table():
     #cols = df.columns.tolist() # view df columns names
     #orderedcols = ordercolumns(cols)
     #print(df.to_string())
-    print(df.to_string(index=False,justify="left"))
+    print(df[['SampleName', 'NReads', 'NMappedReads', 'NUniqMappedReads', 'NRF', 'PBC1', 'PBC2', 'FragmentLength', 'NSC', 'RSC', 'Qtag']].to_string(index=False,justify="left"))
 
 
 if __name__ == '__main__':

--- a/Results-template/Scripts/createtable
+++ b/Results-template/Scripts/createtable
@@ -35,7 +35,7 @@ def file2table():
     #print(df[['NSC', 'FRiP', 'PCB1', 'PCB2', 'RSC']])  #re-order columns
     #cols = df.columns.tolist() # view df columns names
     #orderedcols = ordercolumns(cols)
-#    print(df.to_string())
+    #print(df.to_string())
     print(df.to_string(index=False,justify="left"))
 
 

--- a/Results-template/Scripts/createtable
+++ b/Results-template/Scripts/createtable
@@ -2,7 +2,7 @@
 '''
 Author:		Skyler Kuhn
 Date created:	08/18/2018
-Last modified:	08/23/2018
+Last modified:	04/17/2019 by Tovah Markowitz: markowitzte@nih.gov
 Email:		kuhnsa@nih.gov
 
 About: This program takes standard input from the concatenation of each *qc.metric file.The results 
@@ -30,10 +30,14 @@ def file2table():
             pass
     
     df = pd.DataFrame(tabledict)
+    df.index.name = 'SampleName'
+    df.reset_index(inplace=True)
     #print(df[['NSC', 'FRiP', 'PCB1', 'PCB2', 'RSC']])  #re-order columns
     #cols = df.columns.tolist() # view df columns names
     #orderedcols = ordercolumns(cols)
-    print(df.to_string())
+#    print(df.to_string())
+    print(df.to_string(index=False,justify="left"))
+
 
 if __name__ == '__main__':
     file2table()

--- a/Results-template/Scripts/filterMetrics
+++ b/Results-template/Scripts/filterMetrics
@@ -33,6 +33,9 @@ About: This program takes in a parsed data from Samtools flagstat, atac_nrf.py, 
 	9.) Find NSC, RSC, Qtag
 	  # awk '{print $(NF-2),$(NF-1),$(NF)}' H3k4me3_gran_1.sorted.Q5DD.ppqt | ./filterMetrics H3k4me3_gran_1 ppqt
 
+	10.) Find the Fragment Length
+	  # awk -F '\t' '{print $3}' H3k4me3_gran_1.sorted.Q5DD.ppqt | awk -F ',' '{print $1}' | ../Scripts/filterMetrics H3k4me3_gran_1 fragLen
+
 Python version(s):	2.7 or 3.X
 
 '''
@@ -61,7 +64,9 @@ def getmetadata(type):
                 metadata = 'NMappedReads'
 	elif type == 'unreads':
                 metadata = 'NUniqMappedReads'
-	return metadata	
+	elif type == 'fragLen':
+		metadata = ['FragmentLength']
+	return metadata
 	
 
 def filteredData(sample, ftype):
@@ -75,7 +80,7 @@ def filteredData(sample, ftype):
 			else:
 				v1, v2 = linelist[0], linelist[1]
 				print("{}\t{}\t{}".format(sample, mtypes, add(v1,v2)))
-		elif ftype == 'ppqt' or ftype == 'ngsqc' or ftype == 'nrf':
+		elif ftype == 'ppqt' or ftype == 'ngsqc' or ftype == 'nrf' or ftype == 'fragLen':
 			mtypes = getmetadata(ftype)
 			for i in range(len(linelist)):
 				print("{}\t{}\t{}".format(sample, mtypes[i], linelist[i]))

--- a/Results-template/Scripts/jaccard_score.py
+++ b/Results-template/Scripts/jaccard_score.py
@@ -20,7 +20,9 @@ from pybedtools import BedTool
 
 def split_infiles(infiles):
     # breaks the infile string with space-delimited file names and creates a list
-    infileList = infiles.split(" ")
+    infileList = infiles.strip("\'").strip('\"').split(" ")
+    if len(infileList) == 1:
+        infileList = infileList[0].split(";")
     return(infileList)
 
 def loop_jaccard(infileList, genomefile):
@@ -32,6 +34,7 @@ def loop_jaccard(infileList, genomefile):
     out = []
     for z in range(nfiles):
         fileA = infileList[z]
+        print("fileA is: " + fileA) 
         a = BedTool(fileA)
         a = a.sort(g=genomefile)
         for y in range(z+1,nfiles):
@@ -68,7 +71,7 @@ def main():
 
     parser = optparse.OptionParser(description=desc)
 
-    parser.add_option('-i', dest='infiles', default='', help='A space-delimited list of \
+    parser.add_option('-i', dest='infiles', default='', help='A space- or semicolon-delimited list of \
 input files for analysis.')
     parser.add_option('-o', dest='outfile', default='', help='The name of the output file \
 where all the jaccard score information will be saved.')

--- a/Results-template/Scripts/ngsqc_plot.py
+++ b/Results-template/Scripts/ngsqc_plot.py
@@ -73,9 +73,9 @@ def name_outimage(directory, ext, group):
 	"""this version uses ext to create the output file name
 	"""
 	if group == "":
-		outfileName =  directory + "/NGSQC." + ext + ".pdf"
+		outfileName =  directory + "/NGSQC." + ext + ".png"
 	else:
-		outfileName =  directory + "/" + group + ".NGSQC." + ext + ".pdf"
+		outfileName =  directory + "/" + group + ".NGSQC." + ext + ".png"
 	return outfileName
 	
 #############################################

--- a/Results-template/Scripts/ngsqc_plot.py
+++ b/Results-template/Scripts/ngsqc_plot.py
@@ -4,12 +4,14 @@
 Name: ngsqc_plot.py
 Created by: Tovah Markowitz
 Date: 1/3/19
+Updated: 4/18/19
 
 Purpose: To take a number of NGSQC_report.txt files and convert into a figure.
 Currently designed to work in case where all files have been moved from their original
 subdirectories and the filename includes information of about the source data. All input
 files must be in the noted directory (not recursive), end with ".NGSQC_report.txt", and
-contain 'ext'. Output figures are named based upon 'ext'.
+contain 'ext'. Output figures are named based upon 'ext'. Now also creates a single output
+table that can be read into the multiqc report.
 """
 
 ##########################################
@@ -54,20 +56,36 @@ def create_plot(ngsqcAll, ext, outfileName):
 	plt.savefig(outfileName)
 	plt.close("all")
 
+def write_ngsqc(ngsqcAll,directory,ext):
+        """to write a set of tables of the ngsqc data used in the image for incorporation
+        into multiqc
+        """
+        for sample in ngsqcAll:
+            if ext == "":
+                outfile = directory + "/" + sample[0] + ".NGSQC.txt"
+            else:
+                outfile = directory + "/" + sample[0] + "." + ext + ".NGSQC.txt"
+            f = open(outfile, 'w')
+            f.write( "\n".join( str(sample[1][0][i]) + "," + str(sample[1][1][i]) for i in range(len(sample[1][0])) ) )
+            f.close()
+
 def all_ngsqc(directory, ext):
-	""" To get the ngsqc data for all NGSQC_report.txt files within a single folder
-	 assumes that all files have been moved from their original subdirectories and 
-	 filename include information about the source of the data
-	"""
-	files = os.listdir(directory)
-	files2 = [ file for file in files if re.search("NGSQC_report.txt",file) ]
-	files3 = [ file for file in files if re.search(ext,file) ]
-	ngsqcAll = [ ]
-	regex = r"(.*)." + re.escape(ext) + r".NGSQC_report.txt"
-	for file in files3:
-		tmp = re.search(regex,file)
-		ngsqcAll.append([ tmp.group(1), read_ngsqc(directory + "/" + file) ])
-	return ngsqcAll
+        """ To get the ngsqc data for all NGSQC_report.txt files within a single folder
+        assumes that all files have been moved from their original subdirectories and 
+        filename include information about the source of the data
+        """
+        files = os.listdir(directory)
+        files2 = [ file for file in files if re.search("NGSQC_report.txt",file) ]
+        files3 = [ file for file in files2 if re.search(ext,file) ]
+        ngsqcAll = [ ]
+        if ext == "":
+            regex = r"(.*).NGSQC_report.txt"
+        else:
+            regex = r"(.*)." + re.escape(ext) + r".NGSQC_report.txt"
+        for file in files3:
+            tmp = re.search(regex,file)
+            ngsqcAll.append([ tmp.group(1), read_ngsqc(directory + "/" + file) ])
+        return ngsqcAll
 
 def name_outimage(directory, ext, group):
 	"""this version uses ext to create the output file name
@@ -106,6 +124,7 @@ the output file name.')
 
 	outfileName = name_outimage(directory, ext, group)
 	ngsqcAll = all_ngsqc(directory, ext)
+	write_ngsqc(ngsqcAll, directory, ext)
 	create_plot(ngsqcAll, ext, outfileName)
 
 #dir='/Users/markowitzte/Desktop/ngsqc'

--- a/Rules/InitialChIPseqQC.snakefile
+++ b/Rules/InitialChIPseqQC.snakefile
@@ -609,10 +609,13 @@ rule deeptools_QC:
         cmd2="plotCorrelation -in "+output.npz+" -o "+output.heatmap+" -c 'spearman' -p 'heatmap' --skipZeros --removeOutliers --plotNumbers"
 	cmd3="plotCorrelation -in "+output.npz+" -o "+output.scatter+" -c 'spearman' -p 'scatterplot' --skipZeros --removeOutliers"
         cmd4="plotPCA -in "+output.npz+" -o "+output.pca
+        cmd5="plotCorrelation -in "+output.npz+" -o "+join(workpath,deeptools_dir,"spearman_heatmap."+wildcards.ext+"_mqc.png")+" -c 'spearman' -p 'heatmap' --skipZeros --removeOutliers --plotNumbers"
 	shell(commoncmd+cmd1)
         shell(commoncmd+cmd2)
 	shell(commoncmd+cmd3)
 	shell(commoncmd+cmd4)
+        if "Q5DD" in wildcards.ext:
+            shell(commoncmd+cmd5)
 
 rule deeptools_fingerprint:
     input:
@@ -925,6 +928,7 @@ rule multiqc:
         join(workpath,"QC"),
         expand(join(workpath,deeptools_dir,"{group}.fingerprint.raw.sorted.Q5DD.tab"),group=groups),
         expand(join(workpath,"QC","{group}.NGSQC.sorted.Q5DD.png"),group=groups),
+        join(workpath,deeptools_dir,"spearman_heatmap.sorted.Q5DD.RPGC.pdf"),
     output:
         join(workpath,"Reports","multiqc_report.html")
     params:

--- a/Rules/InitialChIPseqQC.snakefile
+++ b/Rules/InitialChIPseqQC.snakefile
@@ -850,7 +850,6 @@ rule ngsqc_plot:
         ngsqc=expand(join(workpath,"QC","{name}.sorted.Q5DD.NGSQC_report.txt"),name=samples),
     output:
         png=expand(join(workpath,"QC","{group}.NGSQC.sorted.Q5DD.png"),group=groups),
-	txt=join(workpath,"QC","NGSQC.sorted.Q5DD.txt")
     params:
         rname="pl:ngsqc_plot",
         script=join(workpath,"Scripts","ngsqc_plot.py"),
@@ -860,18 +859,16 @@ rule ngsqc_plot:
         cmd1 = ""
         cmd2 = ""
         cmd3 = ""
-	cmd4 = ""
         for group in groups:
             labels = [ sample for sample in samples if sample in groupdatawinput[group] ]
             cmd1 = cmd1 + "mkdir " + group + "; "
             for label in labels:
                 cmd1 = cmd1 + "cp " + workpath + "/QC/" + label + ".sorted.Q5DD.NGSQC_report.txt " + group + "; " 
             cmd2 = cmd2 + "python " + params.script + " -d '" + group + "' -e 'sorted.Q5DD' -g '" + group + "'; "
-	    cmd3 = cmd3 + "if [ -f NGSQC.sorted.Q5DD.txt ]; then tail -n +2 " + group + "/NGSQC.sorted.Q5DD.txt >> NGSQC.sorted.Q5DD.txt; else cp " + group + "/NGSQC.sorted.Q5DD.txt NGSQC.sorted.Q5DD.txt; fi; "
-            cmd4 = cmd4 + "mv " + group + "/" + group + ".NGSQC.sorted.Q5DD.png " + workpath + "/QC/" + group + ".NGSQC.sorted.Q5DD.png" + "; "
-        cmd5 = "mv NGSQC.sorted.Q5DD.txt " + workpath + "/QC/NGSQC.sorted.Q5DD.txt; "
+            cmd3 = cmd3 + "mv " + group + "/" + group + ".NGSQC.sorted.Q5DD.png " + workpath + "/QC/" + group + ".NGSQC.sorted.Q5DD.png" + "; "
+        cmd4 = "mv */*.sorted.Q5DD.NGSQC.txt " + workpath + "/QC; "
         shell(commoncmd1)
-        shell(commoncmd2 + cmd1 + cmd2 + cmd3 + cmd4 + cmd5)
+        shell(commoncmd2 + cmd1 + cmd2 + cmd3 + cmd4)
 
 rule QCstats:
     input:
@@ -938,14 +935,7 @@ rule multiqc:
     threads: 1
     shell: """
 module load {params.multiqc}
-RE="(QC/.*NGSQC.sorted.Q5DD).png"
-for ngsqc in `ls QC/*.NGSQC.sorted.Q5DD.png`;
-do
-if [[ $ngsqc =~ $RE ]]; then root=${{BASH_REMATCH[1]}}; fi
-cp $ngsqc ${{root}}_mqc.png
-done
 cd Reports && multiqc -f -c {params.qcconfig} --interactive -e cutadapt --ignore {params.dir} -d ../
-rm ../QC/*_mqc.png
 """
 
 

--- a/Rules/InitialChIPseqQC.snakefile
+++ b/Rules/InitialChIPseqQC.snakefile
@@ -154,7 +154,7 @@ if se == 'yes' :
             expand(join(workpath,"QC","{name}.qcmetrics"), name=samples),
             join(workpath,"QC","QCTable.txt"),
 
-    
+
     rule trim_se: # actually trim, filter polyX and remove black listed reads
         input:
             infq=join(workpath,"{name}.R1.fastq.gz"),
@@ -188,7 +188,7 @@ java -Xmx{params.javaram} -jar $PICARDJARPATH/picard.jar SamToFastq VALIDATION_S
 pigz -p 16 ${{sample}}.cutadapt.noBL.fastq;
 mv ${{sample}}.cutadapt.noBL.fastq.gz {output.outfq};
             """
-            
+
     rule kraken_se:
         input:
             fq = join(workpath,trim_dir,"{name}.R1.trim.fastq.gz"),
@@ -335,7 +335,7 @@ if pe == 'yes':
             expand(join(workpath,"QC","{name}.qcmetrics"), name=samples),
             join(workpath,"QC","QCTable.txt"),
 
-    
+
     rule trim_pe: # trim, remove PolyX and remove BL reads
         input:
             file1=join(workpath,"{name}.R1.fastq.gz"),
@@ -898,6 +898,8 @@ grep 'mapped (' {input.ddflagstat} | awk '{{print $1,$3}}' | {params.filterColla
 cat {input.nrf} | {params.filterCollate} {wildcards.name} nrf >> {output.sampleQCfile}
 # NSC, RSC, Qtag
 awk '{{print $(NF-2),$(NF-1),$NF}}' {input.ppqt} | {params.filterCollate} {wildcards.name} ppqt >> {output.sampleQCfile}
+# Fragment Length
+awk -F '\\t' '{{print $3}}' {input.ppqt} | awk -F ',' '{{print $1}}' | {params.filterCollate} {wildcards.name} fragLen >> {output.sampleQCfile}
             """
 
 rule QCTable:

--- a/cluster.json
+++ b/cluster.json
@@ -107,6 +107,15 @@
     "deeptools": {
         "mem": "24g"
     },
+    "deeptools_fingerprint": {
+        "threads":"8"
+    },
+    "deeptools_fingerprint_Q5DD": {
+        "threads":"8"
+    },
+    "deeptools_genes": {
+        "threads":"16"
+    },
     "deeptools_prep": {
         "mem": "4g",
         "threads": "2"


### PR DESCRIPTION
the multiQC report for ChIP-seq will now include:
a ChIP-seq QC table with NSC, RSC, estimated fragment length, NRF, PBC, and number of aligned reads
a line plot from the NGSQC analyses
a clustered spearman correlation image showing similarity between samples