### PR TITLE
Specify R version

### DIFF
--- a/Rules/make.germline.network.rl
+++ b/Rules/make.germline.network.rl
@@ -3,6 +3,6 @@ rule make_germline_network:
     output: network="sample_network_mqc.png",
     params: rname="make.germline.network"
     shell: """
-         perl Scripts/make_sample_network.pl {input}; module load R; Rscript Scripts/magick.R; rm sample_network.bmp
+         perl Scripts/make_sample_network.pl {input}; module load R/3.5; Rscript Scripts/magick.R; rm sample_network.bmp
 
            """


### PR DESCRIPTION
Specify R version (3.5) because default (3.6) does not have 'magick' installed