### PR TITLE
Improved QC Reports - June 2020 (NW)

### DIFF
--- a/Results-template/Scripts/integrateBatches.R
+++ b/Results-template/Scripts/integrateBatches.R
@@ -23,16 +23,19 @@ matrix <- as.character(args[1])
 #output = as.character(args[2])
 outDirSeurat = as.character(args[2])
 outDirMerge = as.character(args[3])
-specie = as.character(args[4])
-resolution = as.character(args[5])
-clusterAlg =  as.numeric(args[6])
-annotDB = as.character(args[7])
-nAnchors = as.numeric(args[8])
-citeseq = as.character(args[9])
-groups = as.character(args[10])
-contrasts = as.character(args[11])
+outImageDir=as.character(args[4])
+specie = as.character(args[5])
+resolution = as.character(args[6])
+clusterAlg =  as.numeric(args[7])
+annotDB = as.character(args[8])
+nAnchors = as.numeric(args[9])
+citeseq = as.character(args[10])
+groups = as.character(args[11])
+contrasts = as.character(args[12])
+
 
 resolution = as.numeric(strsplit(gsub(",+",",",resolution),split=",")[[1]]) #remove excess commas, split into numeric vector
+resolutionString = as.character(strsplit(gsub(",+",",",resolution),split=",")[[1]])
 
 file.names <- dir(path = matrix,pattern ="rds")
 
@@ -154,7 +157,7 @@ runInt = function(obj,res,npcs){
 	      	  obj <- FindClusters(obj, reduction = "pca", dims = 1:npcs, save.SNN = T,resolution = res[i],algorithm = clusterAlg)
 		  }
 		  obj <- RunUMAP(object = obj, reduction = "pca",dims = 1:npcs,n.components = 3)
-		  obj$groups = groupFile$V2[match(obj$Sample,  groupFile$V1,nomatch = F)]
+    if (groups=="YES"){obj$groups = groupFile$V2[match(obj$Sample,  groupFile$V1,nomatch = F)]}
 		  
 		  runSingleR = function(obj,refFile,fineORmain){ #SingleR function call as implemented below
 		  	     avg = AverageExpression(obj,assays = "SCT")
@@ -204,3 +207,64 @@ saveRDS(combinedObj.integrated,outDirSeurat)
 
 combinedObj.integratedRNA = runInt(combinedObj.integratedRNA,resolution,npcs_merge)
 saveRDS(combinedObj.integratedRNA,outDirMerge)
+
+
+#IMAGE OUTPUT
+### Sample output
+
+
+pdf(paste0(outImageDir,"/merged_sample.pdf"))
+DimPlot(combinedObj.integratedRNA,group.by="Sample")
+dev.off()
+
+pdf(paste0(outImageDir,"integrated_sample.pdf"))
+DimPlot(combinedObj.integrated,group.by="Sample")
+dev.off()
+
+### Clusters and silhouettes
+for (res in resolutionString){
+	pdf(paste0(outImageDir,"/clusterResolution_",res,"_merged.pdf"))
+	resMod=as.numeric(gsub("\\.0$","",res))
+	clusterPlot=DimPlot(combinedObj.integratedRNA,group.by=paste0("SCT_snn_res.",resMod),label=T,repel=T)
+	print(clusterPlot + labs(title = paste0("Merged Samples at resolution ",res)))
+	dev.off()
+	
+ pdf(paste0(outImageDir,"/clusterResolution_",res,"_integrated.pdf"))
+	resMod=as.numeric(gsub("\\.0$","",res))
+	clusterPlot=DimPlot(combinedObj.integrated,group.by=paste0("SCT_snn_res.",resMod),label=T,repel=T)
+	print(clusterPlot + labs(title = paste0("Integrated Samples at resolution ",res)))
+	dev.off()
+ 
+ 
+	pdf(paste0(outImageDir,"/silhouetteResolution_",res,"_merged.pdf"))
+
+	Idents(combinedObj.integratedRNA)=paste0("SCT_snn_res.",resMod)
+	coord=Embeddings(combinedObj.integratedRNA,reduction='pca')[,1:30]
+	clusters=Idents(combinedObj.integratedRNA)
+	d = dist(coord,method="euclidean")
+	sil=silhouette(as.numeric(as.character(clusters)),dist=d)
+	palette=alpha(colour=hue_pal()(length(unique(Idents(combinedObj.integratedRNA)))),alpha=0.7)
+	print(plot(sil, col=palette[as.factor(clusters[order(clusters,decreasing=F)])],
+	main=paste0("Silhouette plot of clustering resolution ", res), lty=2,
+	sub=paste("Average silhouette width:",format(round(mean(sil[,3]), 4), nsmall = 4))))
+  
+	abline(v=mean(sil[,3]), col="red4", lty=2)
+	dev.off()
+
+ pdf(paste0(outImageDir,"/silhouetteResolution_",res,"_integrated.pdf"))
+
+	Idents(combinedObj.integrated)=paste0("SCT_snn_res.",resMod)
+	coord=Embeddings(combinedObj.integrated,reduction='pca')[,1:30]
+	clusters=Idents(combinedObj.integrated)
+	d = dist(coord,method="euclidean")
+	sil=silhouette(as.numeric(as.character(clusters)),dist=d)
+	palette=alpha(colour=hue_pal()(length(unique(Idents(combinedObj.integrated)))),alpha=0.7)
+	print(plot(sil, col=palette[as.factor(clusters[order(clusters,decreasing=F)])],
+	main=paste0("Silhouette plot of clustering resolution ", res), lty=2,
+	sub=paste("Average silhouette width:",format(round(mean(sil[,3]), 4), nsmall = 4))))
+  
+	abline(v=mean(sil[,3]), col="red4", lty=2)
+	dev.off()
+}
+
+###

--- a/Results-template/Scripts/integrateBatches.R
+++ b/Results-template/Scripts/integrateBatches.R
@@ -198,30 +198,9 @@ runInt = function(obj,res,npcs){
 																																	   return(obj)
 }
 
-#combinedObj.integrated = runInt(combinedObj.integrated,0.3,npcs_batch)
-#saveRDS(combinedObj.integrated, paste0(outDirSeurat,"_0.3.rds"))
-#combinedObj.integrated = runInt(combinedObj.integrated,0.6,npcs_batch)
-#saveRDS(combinedObj.integrated, paste0(outDirSeurat,"_0.6.rds"))
-#combinedObj.integrated = runInt(combinedObj.integrated,0.8,npcs_batch)
-#saveRDS(combinedObj.integrated, paste0(outDirSeurat,"_0.8.rds"))
-#combinedObj.integrated = runInt(combinedObj.integrated,1.0,npcs_batch)
-#saveRDS(combinedObj.integrated, paste0(outDirSeurat,"_1.0.rds"))
-#combinedObj.integrated = runInt(combinedObj.integrated,1.2,npcs_batch)
-#saveRDS(combinedObj.integrated, paste0(outDirSeurat,"_1.2.rds"))
-
 combinedObj.integrated=runInt(combinedObj.integrated,resolution,npcs_batch)
 saveRDS(combinedObj.integrated,outDirSeurat)
 
-#combinedObj.integratedRNA = runInt(combinedObj.integratedRNA,0.3,npcs_merge)
-#saveRDS(combinedObj.integratedRNA, paste0(outDirMerge,"_0.3.rds"))
-#combinedObj.integratedRNA = runInt(combinedObj.integratedRNA,0.6,npcs_merge)
-#saveRDS(combinedObj.integratedRNA, paste0(outDirMerge,"_0.6.rds"))
-#combinedObj.integratedRNA = runInt(combinedObj.integratedRNA,0.8,npcs_merge)
-#saveRDS(combinedObj.integratedRNA, paste0(outDirMerge,"_0.8.rds"))
-#combinedObj.integratedRNA = runInt(combinedObj.integratedRNA,1.0,npcs_merge)
-#saveRDS(combinedObj.integratedRNA, paste0(outDirMerge,"_1.0.rds"))
-#combinedObj.integratedRNA = runInt(combinedObj.integratedRNA,1.2,npcs_merge)
-#saveRDS(combinedObj.integratedRNA, paste0(outDirMerge,"_1.2.rds"))
 
 combinedObj.integratedRNA = runInt(combinedObj.integratedRNA,resolution,npcs_merge)
 saveRDS(combinedObj.integratedRNA,outDirMerge)

--- a/Results-template/Scripts/integrateBatches.R
+++ b/Results-template/Scripts/integrateBatches.R
@@ -14,7 +14,8 @@ library(dplyr)
 library(Matrix) 
 library(tools)
 library(stringr)
-
+library(cluster)
+library(scales)
 
 
 args <- commandArgs(trailingOnly = TRUE)
@@ -33,9 +34,10 @@ citeseq = as.character(args[10])
 groups = as.character(args[11])
 contrasts = as.character(args[12])
 
-
-resolution = as.numeric(strsplit(gsub(",+",",",resolution),split=",")[[1]]) #remove excess commas, split into numeric vector
 resolutionString = as.character(strsplit(gsub(",+",",",resolution),split=",")[[1]])
+resolution = as.numeric(strsplit(gsub(",+",",",resolution),split=",")[[1]]) #remove excess commas, split into numeric vector
+
+print(resolutionString)
 
 file.names <- dir(path = matrix,pattern ="rds")
 
@@ -219,7 +221,7 @@ pdf(paste0(outImageDir,"/merged_sample.pdf"))
 DimPlot(combinedObj.integratedRNA,group.by="Sample")
 dev.off()
 
-pdf(paste0(outImageDir,"integrated_sample.pdf"))
+pdf(paste0(outImageDir,"/integrated_sample.pdf"))
 DimPlot(combinedObj.integrated,group.by="Sample")
 dev.off()
 

--- a/Results-template/Scripts/integrateBatches.R
+++ b/Results-template/Scripts/integrateBatches.R
@@ -39,6 +39,8 @@ resolutionString = as.character(strsplit(gsub(",+",",",resolution),split=",")[[1
 
 file.names <- dir(path = matrix,pattern ="rds")
 
+file.names = grep("doublets",file.names,invert=T,value=T)
+
 if (groups == "YES") {   
    groupFile = read.delim("groups.tab",header=F,stringsAsFactors = F)
    groupFile=groupFile[groupFile$V2 %in% stringr::str_split_fixed(contrasts,pattern = "-",n = Inf)[1,],]

--- a/Results-template/Scripts/scrnaQC.R
+++ b/Results-template/Scripts/scrnaQC.R
@@ -140,7 +140,7 @@ if (citeseq=="Yes"){
 	so_BC = NormalizeData(so_BC,assay="CITESeq",normalization.method="CLR")
 	so_BC = ScaleData(so_BC,assay="CITESeq")
 }else{
-	if (length(fileInput)==1){
+	if (is.list(fileInput)==FALSE){
 		so_BC = CreateSeuratObject(fileInput)
 	}
 	else{

--- a/Results-template/Scripts/scrnaQC.R
+++ b/Results-template/Scripts/scrnaQC.R
@@ -334,7 +334,7 @@ for (res in resolutionString){
 	pdf(paste0(outImageDir,"/silhouetteResolution_",res,"_",sample,".pdf"))
 
 	Idents(so_noDoublet)=paste0("SCT_snn_res.",resMod)
-	coord=Embeddings(so_noDoublet,reduction='pca')[,1:so@misc$npcs]
+	coord=Embeddings(so_noDoublet,reduction='pca')[,1:so_noDoublet@misc$npcs]
 	clusters=Idents(so_noDoublet)
 	d = dist(coord,method="euclidean")
 	sil=silhouette(as.numeric(as.character(clusters)),dist=d)

--- a/Results-template/Scripts/scrnaQC.R
+++ b/Results-template/Scripts/scrnaQC.R
@@ -142,8 +142,7 @@ if (citeseq=="Yes"){
 }else{
 	if (is.list(fileInput)==FALSE){
 		so_BC = CreateSeuratObject(fileInput)
-	}
-	else{
+	}	else{
 		so_BC = CreateSeuratObject(fileInput[[1]])
 	}
 }

--- a/Results-template/Scripts/scrnaQC.Rmd
+++ b/Results-template/Scripts/scrnaQC.Rmd
@@ -84,6 +84,7 @@ p2 <- ggdraw() + draw_image(list.files(pattern = "Venn.*png$"), scale = 1)
 plot_grid(p1, p2)
 
 ```
+
 ### Cell Filtering Criteria {.tabset}
 
 #### nFeature

--- a/Results-template/Scripts/scrnaQC.Rmd
+++ b/Results-template/Scripts/scrnaQC.Rmd
@@ -1,44 +1,153 @@
 ---
+title: "Sample QC report"
+author: "CCBR_Pipeliner"
+date: '`r format(Sys.time(), "%a %b %d %Y - %X")`'
+output:
+  #pdf_document: default
+  html_document: default
 params:
-  dir: "path/to/count/matrix"
+  dir: "path/to/image/directory"
+  resolution: "csvListResolutions"
+  sample: "sample"
+geometry:
+  margins:0.25in
 ---
 
-```{r headers, include=FALSE, warning=FALSE, message=FALSE}
-dateandtime<-format(Sys.time(), "%a %b %d %Y - %X")
-dir<-params$dir
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+	echo = FALSE,
+	message = FALSE,
+	warning = FALSE
+)
+knitr::opts_knit$set(
+  root.dir=params$dir
+)
 ```
 
-
-
-```{r setup, echo=FALSE, warning=FALSE,message=FALSE,fig.keep='all'}
+```{r message=FALSE, warning=FALSE}
 .libPaths("/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_3.6.1_scRNA")
+library(magick)
+library(ggplot2)
+library(cowplot)
+
+
+library(BiocGenerics)
+library(Biobase)#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_3.6.0_scRNA")
+library(farver)#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_3.6.0_scRNA")
+library(S4Vectors)#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_3.6.0_scRNA")
 library("Seurat")#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/scrna_lib/")
-#opts_chunk$set(root.dir = dir)
+library("DoubletFinder")#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/scrna_lib/")
+library(AnnotationDbi)
+library("modes")#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/scrna_lib/")
+
+library(SingleR)
+library(scRNAseq)
+library(SingleCellExperiment)
+library("URD")#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/scrna_lib/")
+library(Routliers)#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/scrna_lib/")
+library(dplyr)
+library(Matrix) 
+library(reshape2)
+library(tools)
+library("DoubletFinder")#,lib.loc="/data/CCBR_Pipeliner/db/PipeDB/scrna_lib/")
+library(VennDiagram)
+library(ggplot2)
+library(scales)
+library(cluster)
+
+```
+
+```{r message=FALSE, warning=FALSE}
+fileTitle=paste("Sample ID",params$sample)
+
+#NOTES/TO-DO
+# the y axis tick/label texts are tiny and hard to read (for the nFeature, nCount, and mito.pct)
+# suggestions: enlarge (bold) the y axis ticks and labels, and/or make them have the same range, for ease of visual comparions
+# add plot title to the nFeature, nCount and mito.pct plots - NW: addressed by enlarging image 
+# output every SingleR annotations - NW:Add new scrnaQC plot
+
+#Enlarge Venn Diagram title
+#Enlarge Violin titles and axis labels
+#Remove violin legend
+#tinker with silhouette score value image
+```
+
+## `r fileTitle` 
+
+
+```{r prelimStats, fig.width=15, fig.height=7}
+message(getwd())
+p1 <- ggdraw() + draw_image(list.files(pattern = "filterStats"), scale = 1.5,x = 0.2, y=-0.3)
+p2 <- ggdraw() + draw_image(list.files(pattern = "Venn.*png$"), scale = 1)
+
+plot_grid(p1, p2)
+
+```
+### Cell Filtering Criteria {.tabset}
+
+#### nFeature
+```{r nFeature,fig.width=15, fig.height=9}
+p1 <- ggdraw() + draw_image(list.files(pattern = "nFeature_preFilter"), scale = 1)
+p2 <- ggdraw() + draw_image(list.files(pattern = "nFeature_postFilter"), scale = 1)
+p3 <- ggdraw() + draw_image(list.files(pattern = "nCount_preFilter"), scale = 1)
+p4 <- ggdraw() + draw_image(list.files(pattern = "nCount_postFilter"), scale = 1)
+p5 <- ggdraw() + draw_image(list.files(pattern = "mitoPct_preFilter"), scale = 1)
+p6 <- ggdraw() + draw_image(list.files(pattern = "mitoPct_postFilter"), scale = 1)
+plot_grid(p1, p2,  ncol = 2)
+```
+
+#### nCount
+```{r nCount,fig.width=15, fig.height=9}
+plot_grid(p3, p4, ncol = 2)
+```
+
+#### mitoPCT
+```{r mitoPct, fig.width=15, fig.height=9}
+plot_grid(p5, p6, ncol = 2)
 ```
 
 
-```{r plots, echo=FALSE , warning=FALSE,fig.keep='all',results='asis'}
+#### Doublets 
+```{r Doublets, fig.width=6, fig.height=6}
+p1 <- ggdraw() + draw_image(list.files(pattern = "doublets"), scale = 1)
+plot_grid(p1)
+```
 
-setwd(dir)
-file.names <- dir(path = dir ,pattern =".RData")
+### Cell Annotation {.tabset}
 
-for (file in file.names){
-fullPath=paste0(dir,"/",file)
-load(file)
+#### Cell Cycle 
+```{r CellCycle, fig.width=6, fig.height=6}
+p1<- ggdraw() + draw_image(list.files(pattern = "cellCycle"), scale = 1)
+plot_grid(p1)
+```
 
-Name=strsplit(file,".RData")[[1]][1]
+#### SingleR
+```{r SingleR, fig.width=6, fig.height=6}
+p1 <- ggdraw() + draw_image(list.files(pattern = "primaryAnnotation"), scale = 1)
+plot_grid(p1)
+```
 
-print(Name)
 
-print(VlnPlot(so_BC, features = c("nFeature_RNA", "nCount_RNA", "percent.mt"), ncol = 3)) #before
+### Clustering, Silhouette plots and silhouette scores
 
-print(VlnPlot(so_filt, features = c("nFeature_RNA", "nCount_RNA", "percent.mt"), ncol = 3)) #after
-
-print(DimPlot(so,group.by = "annot")) #annot
- 
-print(DimPlot(so,group.by = "DF_hi.lo")) #double
-
+```{r clusterResults, fig.width=15,fig.height =9, echo=FALSE, results="asis"}
+resString=as.character(strsplit(gsub(",+",",",params$resolution),split=",")[[1]])
+for (res in resString){
+  resMod = gsub("\\.0$","",res)
+  #message(resMod)
+  p1 <- ggdraw() + draw_image(list.files(pattern = paste0("clusterResolution_",resMod)),scale=0.95)
+  p2 <- ggdraw() + draw_image(list.files(pattern = paste0("silhouetteResolution_",resMod)))
+  cat("  \n#### Clustering at Resolution ", res," \n")
+  print(plot_grid(p1,p2))
+  cat("  \n")
 }
 
-
 ```
+
+### session
+
+```{r}
+sessionInfo()
+```
+

--- a/Results-template/Scripts/scrnaQC_Matrix.R
+++ b/Results-template/Scripts/scrnaQC_Matrix.R
@@ -3,6 +3,10 @@
 .libPaths("/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_3.6.1_scRNA")
 print(.libPaths())
 
+#MODIFIED VERSION TO TAKE FILE PATHS TO OUT MATRIX FILES
+#MATRIX OUT DIRECTORIES CONTAIN 3 FILES: 
+#barcodes.tsv.gz, features.tsv.gz (formerly genes.tsv.gz), matrix.mtx.gz
+
 args <- commandArgs(trailingOnly = TRUE)
 
 file <- as.character(args[1])
@@ -132,7 +136,7 @@ convertHumanGeneList <- function(x){
   
   return(humanx)
 }
-fileInput = Read10X_h5(matrix)
+fileInput = Read10X(matrix)
 
 if (citeseq=="Yes"){
 	so_BC = CreateSeuratObject(fileInput[[1]])
@@ -340,9 +344,7 @@ for (res in resolutionString){
 	d = dist(coord,method="euclidean")
 	sil=silhouette(as.numeric(as.character(clusters)),dist=d)
 	palette=alpha(colour=hue_pal()(length(unique(Idents(so_noDoublet)))),alpha=0.7)
-	print(plot(sil, col=palette[as.factor(clusters[order(clusters,decreasing=F)])],
-	main=paste0("Silhouette plot of clustering resolution ", res), lty=2,
-	sub=paste("Average silhouette width:",format(round(mean(sil[,3]), 4), nsmall = 4))))
+	print(plot(sil, col=palette[as.factor(clusters[order(clusters,decreasing=F)])], main=paste0("Silhouette plot of clustering resolution ", res), lty=2))
   
 	abline(v=mean(sil[,3]), col="red4", lty=2)
 	dev.off()
@@ -355,26 +357,7 @@ singleRPlot=DimPlot(so_noDoublet,group.by="annot",label=T,repel=T)
 print(singleRPlot + labs(title = paste0(sample," annotations by ",annotDB)))
 dev.off()
 
-pdf(paste0(outImageDir,"/primaryAnnotationCounts_",sample,".pdf"))
-library(gridExtra)
-df=data.frame(sort(table(so_noDoublet$annot),decreasing=T))
-nTypes=length(table(so_noDoublet$annot))
-names(df)=c("CellAnnot","Count")
-if (nTypes <= 15){
-	grid.table(df,rows=NULL)
-}else{
-	if ((nTypes%%2)==1){
-		addition = as.data.frame(matrix(ncol=2,nrow=1))
-		names(addition)=names(df)
-		addition[]=""
-		df = rbind(df,addition)
-	}
-	cutoff=nrow(df)/2
-	grid.table(cbind(df[1:cutoff,],df[(cutoff+1):nrow(df),]),rows=NULL)
-}
-dev.off()
-
-#All cell type annotations ####NEED TO FIGURE BEST WAY TO COUNT CELL TYPES-grid.table with modulus to max out at 4 columns between labels and counts
+#All cell type annotations ####NEED TO FIGURE BEST WAY TO COUNT CELL TYPES-two columns, paste_grid or something like that
 if(species == "human"){
 	annotList=c("HPCA","BP_encode","monaco","dice","Novershtern")
 	for (annot in annotList){

--- a/Results-template/Scripts/scrnaQC_RDS.R
+++ b/Results-template/Scripts/scrnaQC_RDS.R
@@ -3,6 +3,9 @@
 .libPaths("/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_3.6.1_scRNA")
 print(.libPaths())
 
+#MODIFIED VERSION TO ACCEPT RDS FILES
+#IMMEDIATE ASSUMPTION OF NO ADDITIONAL QC PERFORMED YET, AS TYPICAL OUTPUT FROM POST-CELL HASHING
+
 args <- commandArgs(trailingOnly = TRUE)
 
 file <- as.character(args[1])
@@ -132,21 +135,23 @@ convertHumanGeneList <- function(x){
   
   return(humanx)
 }
-fileInput = Read10X_h5(matrix)
+#fileInput = Read10X_h5(matrix)
 
-if (citeseq=="Yes"){
-	so_BC = CreateSeuratObject(fileInput[[1]])
-	so_BC[['CITESeq']] = CreateAssayObject(counts=fileInput[[2]])
-	so_BC = NormalizeData(so_BC,assay="CITESeq",normalization.method="CLR")
-	so_BC = ScaleData(so_BC,assay="CITESeq")
-}else{
-	if (is.list(fileInput)==FALSE){
-		so_BC = CreateSeuratObject(fileInput)
-	}
-	else{
-		so_BC = CreateSeuratObject(fileInput[[1]])
-	}
-}
+#if (citeseq=="Yes"){
+#	so_BC = CreateSeuratObject(fileInput[[1]])
+#	so_BC[['CITESeq']] = CreateAssayObject(counts=fileInput[[2]])
+#	so_BC = NormalizeData(so_BC,assay="CITESeq",normalization.method="CLR")
+#	so_BC = ScaleData(so_BC,assay="CITESeq")
+#}else{
+#	if (is.list(fileInput)==FALSE){
+#		so_BC = CreateSeuratObject(fileInput)
+#	}
+#	else{
+#		so_BC = CreateSeuratObject(fileInput[[1]])
+#	}
+#}
+
+so_BC=readRDS(matrix)
 
 if(species=="human"){so_BC[["percent.mt"]] <- PercentageFeatureSet(so_BC, pattern = "^MT-")}
 if(species=="mouse"){so_BC[["percent.mt"]] <- PercentageFeatureSet(so_BC, pattern = "^mt-")}
@@ -340,9 +345,7 @@ for (res in resolutionString){
 	d = dist(coord,method="euclidean")
 	sil=silhouette(as.numeric(as.character(clusters)),dist=d)
 	palette=alpha(colour=hue_pal()(length(unique(Idents(so_noDoublet)))),alpha=0.7)
-	print(plot(sil, col=palette[as.factor(clusters[order(clusters,decreasing=F)])],
-	main=paste0("Silhouette plot of clustering resolution ", res), lty=2,
-	sub=paste("Average silhouette width:",format(round(mean(sil[,3]), 4), nsmall = 4))))
+	print(plot(sil, col=palette[as.factor(clusters[order(clusters,decreasing=F)])], main=paste0("Silhouette plot of clustering resolution ", res), lty=2))
   
 	abline(v=mean(sil[,3]), col="red4", lty=2)
 	dev.off()
@@ -355,26 +358,7 @@ singleRPlot=DimPlot(so_noDoublet,group.by="annot",label=T,repel=T)
 print(singleRPlot + labs(title = paste0(sample," annotations by ",annotDB)))
 dev.off()
 
-pdf(paste0(outImageDir,"/primaryAnnotationCounts_",sample,".pdf"))
-library(gridExtra)
-df=data.frame(sort(table(so_noDoublet$annot),decreasing=T))
-nTypes=length(table(so_noDoublet$annot))
-names(df)=c("CellAnnot","Count")
-if (nTypes <= 15){
-	grid.table(df,rows=NULL)
-}else{
-	if ((nTypes%%2)==1){
-		addition = as.data.frame(matrix(ncol=2,nrow=1))
-		names(addition)=names(df)
-		addition[]=""
-		df = rbind(df,addition)
-	}
-	cutoff=nrow(df)/2
-	grid.table(cbind(df[1:cutoff,],df[(cutoff+1):nrow(df),]),rows=NULL)
-}
-dev.off()
-
-#All cell type annotations ####NEED TO FIGURE BEST WAY TO COUNT CELL TYPES-grid.table with modulus to max out at 4 columns between labels and counts
+#All cell type annotations ####NEED TO FIGURE BEST WAY TO COUNT CELL TYPES-two columns, paste_grid or something like that
 if(species == "human"){
 	annotList=c("HPCA","BP_encode","monaco","dice","Novershtern")
 	for (annot in annotList){

--- a/Results-template/Scripts/scrnaQC_Reports.R
+++ b/Results-template/Scripts/scrnaQC_Reports.R
@@ -1,9 +1,11 @@
 args <- commandArgs(trailingOnly = TRUE)
 
-dir <- as.character(args[1])
-setwd(dir)
+inputDir <- as.character(args[1])
+outputDir <- as.character(args[2])
+resolution <- as.character(args[3])
+sample = as.character(args[4])
 #sample=strsplit(dir,".Rdat")[[1]][1]
 #outDir = as.character(args[2])
-rmarkdown::render("../Scripts/scrnaQC.Rmd", output_file="samples_QC.html", params = list(
-  dir=dir
-))
+rmarkdown::render("Scripts/scrnaQC.Rmd", output_file=paste0("QC_Report_",sample,".html"),output_dir = outputDir,
+        params = list(dir=inputDir, resolution = resolution, sample= sample)
+)

--- a/Rules/scrnaQC.snakefile
+++ b/Rules/scrnaQC.snakefile
@@ -63,7 +63,7 @@ rule all:
 		expand(join(workpath,"QC","QC_Report_{name}.html"),name=samples),
 		expand(join(workpath,"integration","seurat_batch_corrected","{myGroups}","{myGroups}.rds"),myGroups=contList),
 		expand(join(workpath,"integration","merged","{myGroups}","{myGroups}.rds"),myGroups=contList),
-		expand(join(workpath,"QC","integration","{myGroups}"),myGroups=contList),
+		expand(join(workpath,"integration","QC","{myGroups}"),myGroups=contList),
 		
 rule qc_scrna:
 	input: 
@@ -124,7 +124,7 @@ rule integratedBatch:
 	output:
 		rdsBatch=join(workpath,"integration","seurat_batch_corrected","{myGroups}","{myGroups}.rds"),
 		mergeRDS=join(workpath,"integration","merged","{myGroups}","{myGroups}.rds"),
-		jointImageDir=join(workpath,"QC","integration","{myGroups}","images")
+		jointImageDir=join(workpath,"integration","QC","{myGroups}","images")
 	params:
 		rname='pl:integratedBatch',
 		batch='--cpus-per-task=8 --mem=48g --time=24:00:00',

--- a/Rules/scrnaQC.snakefile
+++ b/Rules/scrnaQC.snakefile
@@ -123,6 +123,7 @@ rule integratedBatch:
 	output:
 		rdsBatch=join(workpath,"integration","seurat_batch_corrected","{myGroups}","{myGroups}.rds"),
 		mergeRDS=join(workpath,"integration","merged","{myGroups}","{myGroups}.rds"),
+		imageDir=join(workpath,"QC","integration","images")
 	params:
 		rname='pl:integratedBatch',
 		batch='--cpus-per-task=8 --mem=48g --time=24:00:00',
@@ -139,7 +140,7 @@ rule integratedBatch:
 		contrasts = "{myGroups}"
 	shell: """
 module load R/3.6.1;
-Rscript Scripts/integrateBatches.R {params.dir} {output.rdsBatch} {output.mergeRDS} {params.specie} {params.resolution} {params.clustAlg} {params.annotDB} {params.nAnchors} {params.citeseq} {params.groups} {params.contrasts};
+Rscript Scripts/integrateBatches.R {params.dir} {output.rdsBatch} {output.mergeRDS} {output.imageDir} {params.specie} {params.resolution} {params.clustAlg} {params.annotDB} {params.nAnchors} {params.citeseq} {params.groups} {params.contrasts};
 	"""
 
 

--- a/Rules/scrnaQC.snakefile
+++ b/Rules/scrnaQC.snakefile
@@ -19,6 +19,13 @@ citeseq = config['project']['CITESEQ']
 nAnchors = "2000"
 groups = "YES" #YES/NO
 
+filterType = ['nFeature','nCount','mitoPct']
+filtStatus = ['preFilter','postFilter']
+
+filtList = []
+for q in filterType:
+	for r in filtStatus:
+		filtList.append(str(q+"_"+r))
 
 contList = []
 contrasts = open("contrasts.tab")
@@ -27,6 +34,9 @@ for line in contrasts:
 #	print(re.sub('\t', '-',  line))
 	contList.append(re.sub('\t', '-',  line))
 
+print("{}".format(contList[0]))
+
+resList = resolution.split(",")
 
 intType = ["seurat_batch_corrected","merged"]
 
@@ -34,20 +44,43 @@ rule all:
 	params:
 		batch='--time=168:00:00',
 	input:
-		expand(join(workpath,"QC","{name}.RData"),name=samples),
+		# expand(join(workpath,"QC","{name}.RData"),name=samples),
+		#QC file outputs
 		expand(join(workpath,"filtered","{name}.rds"),name=samples),
 		expand(join(workpath,"flags","{name}.txt"),name=samples),
-		join(workpath,"QC","samples_QC.html"),		
+		expand(join(workpath,"filtered","{name}_doublets.rds"),name=samples),
+		#QC image outputs
+		expand(join(workpath,"QC","{name}","images","filterStats_{name}.png"),name=samples),
+		expand(join(workpath,"QC","{name}","images","cellsRemovedVenn_{name}.png"),name=samples),
+		expand(join(workpath,"QC","{name}","images","{filt}_{time}_{name}.pdf"),name=samples,filt=filterType,time=filtStatus),
+		expand(join(workpath,"QC","{name}","images","clusterResolution_{res}_{name}.pdf"),name=samples,res=resList),
+		expand(join(workpath,"QC","{name}","images","silhouetteResolution_{res}_{name}.pdf"),name=samples,res=resList),
+		expand(join(workpath,"QC","{name}","images","primaryAnnotation_{name}.pdf"),name=samples),
+		expand(join(workpath,"QC","{name}","images","doublets_{name}.pdf"),name=samples),
+		expand(join(workpath,"QC","{name}","images","cellCycle_{name}.pdf"),name=samples),
+
+		#join(workpath,"QC","samples_QC.html"),
+		expand(join(workpath,"QC","QC_Report_{name}.html"),name=samples),
 		expand(join(workpath,"integration","seurat_batch_corrected","{myGroups}","{myGroups}.rds"),myGroups=contList),
 		expand(join(workpath,"integration","merged","{myGroups}","{myGroups}.rds"),myGroups=contList),
 		
 rule qc_scrna:
 	input: 
-		join(workpath,"{name}.h5")
+		join(workpath,"{name}.h5"),
 	output: 
 		rds=join(workpath,"filtered","{name}.rds"),
-		rdata=join(workpath,"QC","{name}.RData"),
+		#rdata=join(workpath,"QC","{name}.RData"),
 		qc = join(workpath,"flags","{name}.txt"),
+		doublets=join(workpath,"filtered","{name}_doublets.rds"),
+		filtStats=join(workpath,"QC","{name}","images","filterStats_{name}.png"),
+		venn=join(workpath,"QC","{name}","images","cellsRemovedVenn_{name}.png"),
+		filtVln=expand(join(workpath,"QC","{{name}}","images","{filt}_{{name}}.pdf"),filt=filtList),
+		clustUMAP=expand(join(workpath,"QC","{{name}}","images","clusterResolution_{res}_{{name}}.pdf"),res=resList),
+		clustSil=expand(join(workpath,"QC","{{name}}","images","silhouetteResolution_{res}_{{name}}.pdf"),res=resList),
+		annotUMAP=join(workpath,"QC","{name}","images","primaryAnnotation_{name}.pdf"),
+		doubletUMAP=join(workpath,"QC","{name}","images","doublets_{name}.pdf"),
+		cellCycleUMAP=join(workpath,"QC","{name}","images","cellCycle_{name}.pdf"),
+		imageDir = join(workpath,"QC","{name}","images"),
 	params:
 		rname='pl:qc_scrna',
 		specie = specie, 
@@ -55,27 +88,33 @@ rule qc_scrna:
 		clustAlg = clustAlg,
 		annotDB = annotDB,
 		citeseq = citeseq,
-		outDir= join(workpath,"QC")
+		outDir= join(workpath,"QC"),
+		imageDir = join(workpath,"QC","{name}","images")
+
 	shell: """
 
 module load R/3.6.1;
-Rscript Scripts/scrnaQC.R {input} {output.rds} {output.rdata} {params.specie} {params.resolution} {params.clustAlg} {params.annotDB} {params.citeseq};
+Rscript Scripts/scrnaQC.R {input} {output.rds} {params.imageDir} {params.specie} {params.resolution} {params.clustAlg} {params.annotDB} {params.citeseq};
 touch {output.qc}
         """
+#Rscript Scripts/scrnaQC.R {input} {output.rds} {output.rdata} {params.specie} {params.resolution} {params.clustAlg} {params.annotDB} {params.citeseq};
 
 rule qcReport_scrna:
 	input:
-		files = expand(join(workpath,"QC","{name}.RData"),name=samples),
-		path=join (workpath, "QC")
+		# files = expand(join(workpath,"QC","{name}.RData"),name=samples),
+		path=join(workpath,"QC","{name}","images"),
 	output:
-		join(workpath,"QC","samples_QC.html")
+		out=join(workpath,"QC","QC_Report_{name}.html"),
 	params:
 		rname='pl:qcReport_scrna',
+		resolution=resolution,
+		sample = "{name}",
+		outPath = join(workpath,"QC")
 	shell: """
 module load R/3.6.1;
-Rscript Scripts/scrnaQC_Reports.R {input.path};
-mv Scripts/samples_QC.html QC
+Rscript Scripts/scrnaQC_Reports.R {input.path} {params.outPath} {params.resolution} {params.sample};
 	"""
+# mv Scripts/samples_QC.html QC
 	
 rule integratedBatch:
 	input:

--- a/Rules/scrnaQC.snakefile
+++ b/Rules/scrnaQC.snakefile
@@ -63,7 +63,7 @@ rule all:
 		expand(join(workpath,"QC","QC_Report_{name}.html"),name=samples),
 		expand(join(workpath,"integration","seurat_batch_corrected","{myGroups}","{myGroups}.rds"),myGroups=contList),
 		expand(join(workpath,"integration","merged","{myGroups}","{myGroups}.rds"),myGroups=contList),
-		expand(join(workpath,"integration","QC","{myGroups}"),myGroups=contList),
+		expand(join(workpath,"integration","QC","{myGroups}","images"),myGroups=contList),
 		
 rule qc_scrna:
 	input: 
@@ -141,6 +141,7 @@ rule integratedBatch:
 		contrasts = "{myGroups}"
 	shell: """
 module load R/3.6.1;
+if [ ! -d {output.jointImageDir} ]; then mkdir {output.jointImageDir}; fi
 Rscript Scripts/integrateBatches.R {params.dir} {output.rdsBatch} {output.mergeRDS} {output.jointImageDir} {params.specie} {params.resolution} {params.clustAlg} {params.annotDB} {params.nAnchors} {params.citeseq} {params.groups} {params.contrasts};
 	"""
 

--- a/Rules/scrnaQC.snakefile
+++ b/Rules/scrnaQC.snakefile
@@ -63,6 +63,7 @@ rule all:
 		expand(join(workpath,"QC","QC_Report_{name}.html"),name=samples),
 		expand(join(workpath,"integration","seurat_batch_corrected","{myGroups}","{myGroups}.rds"),myGroups=contList),
 		expand(join(workpath,"integration","merged","{myGroups}","{myGroups}.rds"),myGroups=contList),
+		expand(join(workpath,"QC","integration","{myGroups}"),myGroups=contList),
 		
 rule qc_scrna:
 	input: 
@@ -123,7 +124,7 @@ rule integratedBatch:
 	output:
 		rdsBatch=join(workpath,"integration","seurat_batch_corrected","{myGroups}","{myGroups}.rds"),
 		mergeRDS=join(workpath,"integration","merged","{myGroups}","{myGroups}.rds"),
-		imageDir=join(workpath,"QC","integration","images")
+		jointImageDir=join(workpath,"QC","integration","{myGroups}","images")
 	params:
 		rname='pl:integratedBatch',
 		batch='--cpus-per-task=8 --mem=48g --time=24:00:00',
@@ -140,7 +141,7 @@ rule integratedBatch:
 		contrasts = "{myGroups}"
 	shell: """
 module load R/3.6.1;
-Rscript Scripts/integrateBatches.R {params.dir} {output.rdsBatch} {output.mergeRDS} {output.imageDir} {params.specie} {params.resolution} {params.clustAlg} {params.annotDB} {params.nAnchors} {params.citeseq} {params.groups} {params.contrasts};
+Rscript Scripts/integrateBatches.R {params.dir} {output.rdsBatch} {output.mergeRDS} {output.jointImageDir} {params.specie} {params.resolution} {params.clustAlg} {params.annotDB} {params.nAnchors} {params.citeseq} {params.groups} {params.contrasts};
 	"""
 
 


### PR DESCRIPTION
### Changes pushed June 2020
**scrnaQC.R**
Catch for only importing reads in event of multi-assay h5 file
Saving npcs as metadata in misc array
QC Image outputs at end of script:
- List of statistics
- Venn diagram
- Violins pre- and post-filter
- Cluster UMAPs and silhouettes
- Pre-doublet filter UMAP
- Cell cycle UMAP
- QC images for all annotations datasets

Save seurat object pre-doublet removal 
Remove saving of full Rdata workspaces

**scrnaQC.snakefile**
Include new files produced as input/output for rule all, rule qc_scrna, rule qcReport_scrna. All pdf/png images used to generate QC report.
Modified qcReport_scrna to call expanded scrnaQC_Report.R

**scrnaQC_Report.R**
Added parameters to scrnaQC.Rmd call:
- Output file name
- Output file directory (QC)
- Parameters: Image storage directory, resolution list, sample ID

**scrnaQC.Rmd**
Full re-write of Rmd file to only grab images
New images included described above

**integrateBatches.R**
Cleaned up old calls across multiple clustering resolutions
