### PR TITLE
Fixing reference to /scratch in novocraft sort rule

### DIFF
--- a/Rules/novocraft.sort.rl
+++ b/Rules/novocraft.sort.rl
@@ -3,6 +3,6 @@ rule novocraft_sort:
      output: temp("{x}.sorted.bam")
      params: novosort=config['bin'][pfamily]['NOVOSORT'],rname="pl:novosort"
      threads: 8
-     shell:  "module load novocraft/3.08.02; novosort -t /scratch -m 100G --threads {threads} -s -i -o {output} {input};"
+     shell:  "module load novocraft/3.08.02; novosort -t /lscratch/$SLURM_JOB_ID -m 100G --threads {threads} -s -i -o {output} {input};"
 
 

--- a/cluster.json
+++ b/cluster.json
@@ -596,6 +596,7 @@
     "novocraft_sort": {
         "mem": "120g",
         "threads": "8",
+	"gres": "lscratch:500",
         "time": "2-00:00:00"
     },
     "oncofuse": {


### PR DESCRIPTION
The sort rule for the wgs/wes pipelines was using "/scratch" as a temp directory.  Redirecting to /lscratch.