### PR TITLE
Fixing reference to /scratch in novocraft sort rule in activeDev

### DIFF
--- a/Rules/novocraft.sort.rl
+++ b/Rules/novocraft.sort.rl
@@ -3,6 +3,6 @@ rule novocraft_sort:
      output: temp("{x}.sorted.bam")
      params: novosort=config['bin'][pfamily]['NOVOSORT'],rname="pl:novosort"
      threads: 8
-     shell:  "module load novocraft/3.08.02; novosort -t /scratch -m 100G --threads {threads} -s -i -o {output} {input};"
+     shell:  "module load novocraft/3.08.02; novosort -t /lscratch/$SLURM_JOB_ID -m 100G --threads {threads} -s -i -o {output} {input};"
 
 

--- a/cluster.json
+++ b/cluster.json
@@ -596,7 +596,7 @@
     "novocraft_sort": {
         "mem": "120g",
         "threads": "8",
-	"gres": "lscratch:500",
+        "gres": "lscratch:500",
         "time": "2-00:00:00"
     },
     "oncofuse": {

--- a/cluster.json
+++ b/cluster.json
@@ -52,6 +52,14 @@
         "mem": "64g",
         "threads": "32"
     },
+    "BWA_SE": {
+        "mem": "64g",
+        "threads": "32"
+    },
+    "BWA_PE": {
+        "mem": "64g",
+        "threads": "32"
+    },
     "bwa_mem": {
         "mem": "48g",
         "threads": "32",
@@ -162,6 +170,9 @@
         "mem": "64g",
         "threads": "8",
         "time": "10-00:00:00"
+    },
+    "diffbind": {
+        "threads":"10"
     },
     "diffbind_bed": {
         "mem": "4g",
@@ -610,8 +621,8 @@
     },
     "picard": {
         "gres": "lscratch:256",
-        "mem": "96g",
-        "threads": "2"
+        "mem": "110g",
+        "threads": "6"
     },
     "picard_dedup": {
         "gres": "lscratch:256",

--- a/cluster.json
+++ b/cluster.json
@@ -52,14 +52,6 @@
         "mem": "64g",
         "threads": "32"
     },
-    "BWA_SE": {
-        "mem": "64g",
-        "threads": "32"
-    },
-    "BWA_PE": {
-        "mem": "64g",
-        "threads": "32"
-    },
     "bwa_mem": {
         "mem": "48g",
         "threads": "32",
@@ -170,9 +162,6 @@
         "mem": "64g",
         "threads": "8",
         "time": "10-00:00:00"
-    },
-    "diffbind": {
-        "threads":"10"
     },
     "diffbind_bed": {
         "mem": "4g",
@@ -607,6 +596,7 @@
     "novocraft_sort": {
         "mem": "120g",
         "threads": "8",
+	"gres": "lscratch:500",
         "time": "2-00:00:00"
     },
     "oncofuse": {
@@ -620,8 +610,8 @@
     },
     "picard": {
         "gres": "lscratch:256",
-        "mem": "110g",
-        "threads": "6"
+        "mem": "96g",
+        "threads": "2"
     },
     "picard_dedup": {
         "gres": "lscratch:256",


### PR DESCRIPTION
The sort rule for the wgs/wes pipelines was using "/scratch" as a temp directory. Redirecting to /lscratch.  Repeating for activeDev, already fixed in main.